### PR TITLE
Fixed logic in Animal Antics

### DIFF
--- a/locations/lost_world/Animal_Antics.json
+++ b/locations/lost_world/Animal_Antics.json
@@ -8,7 +8,7 @@
         "sections": [
             {
                 "name": "Clear",
-                "access_rules": ["EASY, squawks, rambi, squitter, rattly, enguarde, swim, barrelkannons, diddy, dixie", "NORMAL, squawks, rambi, squitter, rattly, enguarde, swim, barrelkannons", "HARD, swim, barrelkannons, enguarde, rambi", "HARD, swim, barrelkannons, enguarde, diddy, dixie, teamattack, helicopterspin"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde, rattly", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/clear_disabled.png",
                 "chest_opened_img": "images/checks/clear.png",
                 "visibility_rules": [],
@@ -28,7 +28,7 @@
             "sections": [
                 {
                 "name": "DK Coin",
-                "access_rules": ["EASY, squawks, rambi, squitter, enguarde, swim, diddy, dixie", "NORMAL, squawks, rambi, squitter, enguarde, swim", "HARD, swim, barrelkannons, enguarde, rambi", "HARD, swim, barrelkannons, enguarde, diddy, dixie, teamattack, helicopterspin"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde, rattly", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/dkcoin_disabled.png",
                 "chest_opened_img": "images/checks/dkcoin.png",
                 "visibility_rules": [],
@@ -48,7 +48,7 @@
             "sections": [
                 {
                 "name": "KONG",
-                "access_rules": ["EASY, squawks, rambi, squitter, rattly, enguarde, swim, barrelkannons, diddy, dixie", "NORMAL, squawks, rambi, squitter, rattly, enguarde, swim, barrelkannons", "HARD, swim, barrelkannons, enguarde, rambi", "HARD, swim, barrelkannons, enguarde, diddy, dixie, teamattack, helicopterspin"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde, rattly", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/kong_disabled.png",
                 "chest_opened_img": "images/checks/kong.png",
                 "visibility_rules": ["kongchecks"],
@@ -87,7 +87,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #1 (Near Lockjaw trio)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim", "NORMAL, rambi, enguarde, swim", "HARD, swim, enguarde, rambi", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie"],
+                "access_rules": ["EASY, rambi, enguarde", "NORMAL, rambi, enguarde", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -107,7 +107,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #2 (Behind pillar)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter", "NORMAL, rambi, enguarde, swim, squitter", "HARD, swim, enguarde, rambi", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie"],
+                "access_rules": ["EASY, rambi, enguarde", "NORMAL, rambi, enguarde", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -127,7 +127,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #1 (Between spikes)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter", "NORMAL, rambi, enguarde, swim, squitter", "HARD, swim, enguarde, rambi", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie"],
+                "access_rules": ["EASY, rambi, enguarde, squitter", "NORMAL, rambi, enguarde", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -147,7 +147,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #2 (Behind Zingers)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter, squawks, barrelkannons", "NORMAL, rambi, enguarde, swim, squitter, squawks, barrelkannons", "HARD, swim, enguarde, rambi, barrelkannons", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie, barrelkannons"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -167,7 +167,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #3 (Behind Zingers)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter, squawks, barrelkannons", "NORMAL, rambi, enguarde, swim, squitter, squawks, barrelkannons", "HARD, swim, enguarde, rambi, barrelkannons", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie, barrelkannons"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -187,7 +187,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #4 (Behind Zingers)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter, squawks, barrelkannons", "NORMAL, rambi, enguarde, swim, squitter, squawks, barrelkannons", "HARD, swim, enguarde, rambi, barrelkannons", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie, barrelkannons"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -207,7 +207,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #3 (Behind Zingers)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter, squawks, barrelkannons", "NORMAL, rambi, enguarde, swim, squitter, squawks, barrelkannons", "HARD, swim, enguarde, rambi, barrelkannons", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie, barrelkannons"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -227,7 +227,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #4 (Corner near Red Zingers)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter, squawks, barrelkannons", "NORMAL, rambi, enguarde, swim, squitter, squawks, barrelkannons", "HARD, swim, enguarde, rambi, barrelkannons", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie, barrelkannons"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -247,7 +247,7 @@
             "sections": [
                 {
                 "name": "Red Balloon (Corner before Rattly barrel)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter, squawks, barrelkannons", "NORMAL, rambi, enguarde, swim, squitter, squawks, barrelkannons", "HARD, swim, enguarde, rambi, barrelkannons", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie, barrelkannons"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde", "NORMAL, enguarde, rambi", "HARD, diddy, dixie, enguarde", "HARD, diddy, dixie, swim, squitter"],
                 "chest_unopened_img": "images/checks/swanky1_disabled.png",
                 "chest_opened_img": "images/checks/swanky1.png",
                 "visibility_rules": ["balloonsanity"],
@@ -267,7 +267,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #5 (Rattly sign)",
-                "access_rules": ["EASY, diddy, dixie, rambi, enguarde, swim, squitter, squawks, barrelkannons, rattly", "NORMAL, rambi, enguarde, swim, squitter, squawks, barrelkannons, rattly", "HARD, swim, enguarde, rambi, barrelkannons", "HARD, swim, enguarde, helicopterspin, teamattack, diddy, dixie, barrelkannons"],
+                "access_rules": ["EASY, barrelkannons, squawks, rambi, squitter, enguarde", "NORMAL, barrelkannons, enguarde, rambi, rattly", "HARD, barrelkannons, diddy, dixie, enguarde, rattly", "HARD, barrelkannons, diddy, dixie, swim, squitter, rattly"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],

--- a/locations/lost_world/Black_Ice_Battle.json
+++ b/locations/lost_world/Black_Ice_Battle.json
@@ -8,7 +8,7 @@
         "sections": [
             {
                 "name": "Clear",
-                "access_rules": ["EASY, carry", "NORMAL", "HARD"],
+                "access_rules": [],
                 "chest_unopened_img": "images/checks/clear_disabled.png",
                 "chest_opened_img": "images/checks/clear.png",
                 "visibility_rules": [],
@@ -48,7 +48,7 @@
             "sections": [
                 {
                 "name": "KONG",
-                "access_rules": ["EASY, carry, teamattack, diddy, dixie", "NORMAL, carry", "HARD, carry", "HARD, diddy, dixie"],
+                "access_rules": ["EASY, carry", "NORMAL, carry", "HARD, carry", "HARD, diddy, dixie"],
                 "chest_unopened_img": "images/checks/kong_disabled.png",
                 "chest_opened_img": "images/checks/kong.png",
                 "visibility_rules": ["kongchecks"],
@@ -87,7 +87,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #1 (Behind Krook)",
-                "access_rules": ["EASY, carry, cartwheel", "NORMAL, carry, cartwheel", "HARD, carry", "HARD, helicopterspin, dixie", "HARD, diddy, dixie", "HARD, cartwheel"],
+                "access_rules": ["EASY, carry", "NORMAL, carry", "NORMAL, cartwheel", "HARD, carry", "HARD, helicopterspin, dixie", "HARD, diddy, dixie"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -107,7 +107,7 @@
             "sections": [
                 {
                 "name": "Red Balloon #1 (Above Klobber)",
-                "access_rules": ["EASY, carry", "NORMAL", "HARD"],
+                "access_rules": [],
                 "chest_unopened_img": "images/checks/swanky1_disabled.png",
                 "chest_opened_img": "images/checks/swanky1.png",
                 "visibility_rules": ["balloonsanity"],
@@ -127,7 +127,7 @@
             "sections": [
                 {
                 "name": "Red Balloon #2 (Above Klobber)",
-                "access_rules": ["EASY, carry", "NORMAL", "HARD"],
+                "access_rules": [],
                 "chest_unopened_img": "images/checks/swanky1_disabled.png",
                 "chest_opened_img": "images/checks/swanky1.png",
                 "visibility_rules": ["balloonsanity"],
@@ -167,7 +167,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #2 (4-path left)",
-                "access_rules": ["EASY, carry", "NORMAL", "HARD"],
+                "access_rules": ["EASY, carry", "EASY, dixie, helicopterspin", "NORMAL", "HARD"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -187,7 +187,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #1 (4-path right)",
-                "access_rules": ["EASY, carry", "NORMAL", "HARD"],
+                "access_rules": ["EASY, carry", "EASY, dixie, helicopterspin", "NORMAL", "HARD"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -207,7 +207,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #3 (Next to G)",
-                "access_rules": ["EASY, carry, teamattack, diddy, dixie", "NORMAL, carry", "HARD, carry", "HARD, diddy, dixie"],
+                "access_rules": ["EASY, carry", "NORMAL, carry", "HARD, carry", "HARD, diddy, dixie"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],

--- a/locations/lost_world/Fiery_Furnace.json
+++ b/locations/lost_world/Fiery_Furnace.json
@@ -8,7 +8,7 @@
         "sections": [
             {
                 "name": "Clear",
-                "access_rules": ["EASY, cartwheel, controllablebarrels", "NORMAL, cartwheel, controllablebarrels", "HARD, controllablebarrels, cartwheel", "HARD, controllablebarrels, diddy, dixie"],
+                "access_rules": ["EASY, cartwheel, controllablebarrels", "EASY, dixie, helicopterspin, controllablebarrels", "NORMAL, cartwheel, controllablebarrels", "NORMAL, dixie, helicopterspin, controllablebarrels", "HARD, controllablebarrels, cartwheel", "HARD, dixie, helicopterspin, controllablebarrels", "HARD, controllablebarrels, diddy, dixie"],
                 "chest_unopened_img": "images/checks/clear_disabled.png",
                 "chest_opened_img": "images/checks/clear.png",
                 "visibility_rules": [],
@@ -28,7 +28,7 @@
             "sections": [
                 {
                 "name": "DK Coin",
-                "access_rules": ["EASY, cartwheel, controllablebarrels, teamattack, diddy, dixie", "NORMAL, cartwheel, controllablebarrels, teamattack, diddy, dixie", "HARD, controllablebarrels, cartwheel", "HARD, controllablebarrels, diddy, dixie"],
+                "access_rules": ["EASY, cartwheel, controllablebarrels, teamattack, diddy, dixie", "EASY, helicopterspin, controllablebarrels, teamattack, diddy, dixie", "NORMAL, cartwheel, controllablebarrels", "NORMAL, helicopterspin, controllablebarrels, dixie", "HARD, cartwheel, controllablebarrels", "HARD, helicopterspin, controllablebarrels, dixie"],
                 "chest_unopened_img": "images/checks/dkcoin_disabled.png",
                 "chest_opened_img": "images/checks/dkcoin.png",
                 "visibility_rules": [],
@@ -48,7 +48,7 @@
             "sections": [
                 {
                 "name": "KONG",
-                "access_rules": ["EASY, cartwheel, controllablebarrels, teamattack, diddy, dixie", "NORMAL, cartwheel, controllablebarrels, teamattack, diddy, dixie", "HARD, controllablebarrels, cartwheel", "HARD, controllablebarrels, diddy, dixie"],
+                "access_rules": ["EASY, cartwheel, controllablebarrels, teamattack, diddy, dixie", "EASY, helicopterspin, controllablebarrels, teamattack, diddy, dixie", "NORMAL, cartwheel, controllablebarrels", "NORMAL, helicopterspin, controllablebarrels, teamattack, diddy, dixie", "HARD, cartwheel, controllablebarrels", "HARD, helicopterspin, controllablebarrels, dixie", "HARD, controllablebarrels, diddy, dixie"],
                 "chest_unopened_img": "images/checks/kong_disabled.png",
                 "chest_opened_img": "images/checks/kong.png",
                 "visibility_rules": ["kongchecks"],
@@ -87,7 +87,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #1 (Above start)",
-                "access_rules": ["EASY, teamattack, diddy, dixie", "NORMAL, teamattack, diddy, dixie", "HARD, teamattack, diddy, dixie", "HARD, cartwheel, helicopterspin, dixie"],
+                "access_rules": ["EASY, teamattack, diddy, dixie", "NORMAL, teamattack, diddy, dixie", "HARD, diddy, dixie", "HARD, cartwheel, helicopterspin, dixie"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -107,7 +107,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #2 (Above start)",
-                "access_rules": ["EASY, teamattack, diddy, dixie", "NORMAL, teamattack, diddy, dixie", "HARD, teamattack, diddy, dixie", "HARD, cartwheel, helicopterspin, dixie"],
+                "access_rules": ["EASY, teamattack, diddy, dixie", "NORMAL, teamattack, diddy, dixie", "HARD, diddy, dixie", "HARD, cartwheel, helicopterspin, dixie"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -127,7 +127,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #3 (Above start)",
-                "access_rules": ["EASY, teamattack, diddy, dixie", "NORMAL, teamattack, diddy, dixie", "HARD, teamattack, diddy, dixie", "HARD, cartwheel, helicopterspin, dixie"],
+                "access_rules": ["EASY, teamattack, diddy, dixie", "NORMAL, teamattack, diddy, dixie", "HARD, diddy, dixie", "HARD, cartwheel, helicopterspin, dixie"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -147,7 +147,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #4 (Below Zinger duo)",
-                "access_rules": ["EASY, controllablebarrels, teamattack, diddy, dixie", "NORMAL, controllablebarrels, teamattack, diddy, dixie", "HARD, cartwheel", "HARD, controllablebarrels", "HARD, helicopterspin, dixie"],
+                "access_rules": ["EASY, controllablebarrels", "NORMAL, controllablebarrels", "NORMAL, teamattack, diddy, dixie", "HARD, cartwheel", "HARD, controllablebarrels", "HARD, teamattack, diddy, dixie", "HARD, helicopterspin, dixie"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -167,7 +167,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #1 (Near Controllable Barrel)",
-                "access_rules": ["EASY, cartwheel, controllablebarrels, teamattack, diddy, dixie", "NORMAL, controllablebarrels, teamattack, diddy, dixie, cartwheel", "HARD, controllablebarrels"],
+                "access_rules": ["EASY, controllablebarrels", "NORMAL, controllablebarrels", "HARD, controllablebarrels"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -187,7 +187,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #2 (Ledge before Kutlass)",
-                "access_rules": ["EASY, cartwheel, controllablebarrels, teamattack, diddy, dixie", "NORMAL, controllablebarrels, teamattack, diddy, dixie, cartwheel", "HARD, controllablebarrels"],
+                "access_rules": ["EASY, controllablebarrels", "NORMAL, controllablebarrels", "HARD, controllablebarrels"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -207,7 +207,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #5 (Between moving Zingers)",
-                "access_rules": ["EASY, cartwheel, controllablebarrels, teamattack, diddy, dixie", "NORMAL, controllablebarrels, cartwheel, teamattack, diddy, dixie", "HARD, controllablebarrels, cartwheel", "HARD, controllablebarrels, dixie, helicopterspin"],
+                "access_rules": ["EASY, cartwheel, controllablebarrels", "EASY, dixie, helicopterspin, controllablebarrels", "NORMAL, controllablebarrels, cartwheel", "NORMAL, dixie, helicopterspin, controllablebarrels", "HARD, controllablebarrels, cartwheel", "HARD, controllablebarrels, dixie, helicopterspin"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],

--- a/locations/lost_world/Jungle_Jinx.json
+++ b/locations/lost_world/Jungle_Jinx.json
@@ -10,7 +10,7 @@
         "sections": [
             {
                 "name": "Clear",
-                "access_rules": ["EASY, cartwheel, barrelkannons", "NORMAL, cartwheel, barrelkannons", "HARD, barrelkannons", "HARD, helicopterspin, dixie"],
+                "access_rules": ["EASY, cartwheel, barrelkannons", "NORMAL, cartwheel, barrelkannons", "NORMAL, helicopterspin, dixie", "HARD, barrelkannons"],
                 "chest_unopened_img": "images/checks/clear_disabled.png",
                 "chest_opened_img": "images/checks/clear.png",
                 "visibility_rules": [],
@@ -30,7 +30,7 @@
             "sections": [
                 {
                 "name": "DK Coin",
-                "access_rules": ["EASY, cartwheel, teamattack, diddy, dixie", "NORMAL, cartwheel, teamattack, diddy, dixie", "HARD, teamattack, diddy, dixie, cartwheel", "HARD, teamattack, diddy, dixie, helicopterspin"],
+                "access_rules": ["EASY, cartwheel, teamattack, diddy, dixie", "NORMAL, cartwheel, teamattack, diddy, dixie", "HARD, cartwheel, teamattack, diddy, dixie", "HARD, teamattack, diddy, dixie, helicopterspin"],
                 "chest_unopened_img": "images/checks/dkcoin_disabled.png",
                 "chest_opened_img": "images/checks/dkcoin.png",
                 "visibility_rules": [],
@@ -50,7 +50,7 @@
             "sections": [
                 {
                 "name": "KONG",
-                "access_rules": ["EASY, cartwheel, barrelkannons, carry", "NORMAL, cartwheel, barrelkannons, carry", "HARD, cartwheel, barrelkannons, carry", "HARD, cartwheel, barrelkannons, diddy, dixie", "HARD, cartwheel, helicopterspin, dixie, diddy", "HARD, cartwheel, helicopterspin, dixie, carry"],
+                "access_rules": ["EASY, cartwheel, barrelkannons, carry", "NORMAL, cartwheel, barrelkannons, carry", "HARD, cartwheel, barrelkannons, carry", "HARD, cartwheel, barrelkannons, diddy, dixie", "HARD, helicopterspin, dixie, diddy"],
                 "chest_unopened_img": "images/checks/kong_disabled.png",
                 "chest_opened_img": "images/checks/kong.png",
                 "visibility_rules": ["kongchecks"],
@@ -149,7 +149,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #2 (Above Zinger)",
-                "access_rules": ["EASY, cartwheel", "NORMAL, cartwheel", "HARD"],
+                "access_rules": ["EASY, cartwheel", "EASY, dixie, helicopterspin", "NORMAL, cartwheel", "NORMAL, dixie, helicopterspin", "HARD"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -169,7 +169,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #3 (Arrow barrel)",
-                "access_rules": ["EASY, cartwheel, barrelkannons", "NORMAL, cartwheel, barrelkannons", "HARD, helicopterspin, dixie", "HARD, barrelkannons"],
+                "access_rules": ["EASY, cartwheel, barrelkannons", "NORMAL, cartwheel, barrelkannons", "HARD, helicopterspin, dixie", "HARD, barrelkannons, diddy, dixie, teamattack"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -189,7 +189,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #4 (On top of banana trail)",
-                "access_rules": ["EASY, cartwheel, teamattack, diddy, dixie, barrelkannons", "NORMAL, cartwheel, barrelkannons, teamattack, diddy, dixie", "HARD, helicopterspin, dixie", "HARD, barrelkannons"],
+                "access_rules": ["EASY, cartwheel, teamattack, diddy, dixie, barrelkannons", "EASY, dixie, helicopterspin, barrelkannons", "NORMAL, cartwheel, barrelkannons, teamattack, diddy, dixie", "NORMAL, dixie, helicopterspin, barrelkannons", "HARD, helicopterspin, dixie, diddy", "HARD, barrelkannons"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],

--- a/locations/lost_world/Klobber_Karnage.json
+++ b/locations/lost_world/Klobber_Karnage.json
@@ -8,7 +8,7 @@
         "sections": [
             {
                 "name": "Clear",
-                "access_rules": ["EASY, carry, controllablebarrels, kongbarrels, barrelkannons, diddy, dixie", "NORMAL, carry, controllablebarrels, kongbarrels, barrelkannons, diddy, dixie", "HARD, carry, controllablebarrels, kongbarrels, barrelkannons, diddy, dixie", "HARD, teamattack, barrelkannons, controllablebarrels, kongbarrels, diddy, dixie"],
+                "access_rules": ["EASY, controllablebarrels, kongbarrels, barrelkannons, cartwheel", "EASY, controllablebarrels, kongbarrels, barrelkannons, helicopterspin, dixie", "NORMAL, controllablebarrels, kongbarrels, barrelkannons, cartwheel", "NORMAL, controllablebarrels, kongbarrels, barrelkannons, helicopterspin, dixie", "HARD, controllablebarrels, kongbarrels, barrelkannons"],
                 "chest_unopened_img": "images/checks/clear_disabled.png",
                 "chest_opened_img": "images/checks/clear.png",
                 "visibility_rules": [],
@@ -28,7 +28,7 @@
             "sections": [
                 {
                 "name": "DK Coin",
-                "access_rules": ["EASY, carry, controllablebarrels, kongbarrels, barrelkannons, diddy, dixie, exclamationbarrels", "NORMAL, carry, controllablebarrels, kongbarrels, barrelkannons, diddy, dixie, exclamationbarrels", "HARD, carry, controllablebarrels, kongbarrels, barrelkannons, exclamationbarrels, diddy, dixie", "HARD, teamattack, barrelkannons, exclamationbarrels, controllablebarrels, kongbarrels, diddy, dixie"],
+                "access_rules": ["EASY, controllablebarrels, kongbarrels, barrelkannons, diddy, exclamationbarrels, cartwheel", "EASY, controllablebarrels, kongbarrels, barrelkannons, diddy, exclamationbarrels, dixie, helicopterspin", "NORMAL, controllablebarrels, kongbarrels, barrelkannons, diddy, exclamationbarrels, cartwheel", "NORMAL, controllablebarrels, kongbarrels, barrelkannons, diddy, exclamationbarrels, dixie, helicopterspin", "HARD, controllablebarrels, kongbarrels, barrelkannons, diddy, exclamationbarrels"],
                 "chest_unopened_img": "images/checks/dkcoin_disabled.png",
                 "chest_opened_img": "images/checks/dkcoin.png",
                 "visibility_rules": [],
@@ -48,7 +48,7 @@
             "sections": [
                 {
                 "name": "KONG",
-                "access_rules": ["EASY, carry, controllablebarrels, kongbarrels, barrelkannons, diddy, dixie", "NORMAL, carry, controllablebarrels, kongbarrels, barrelkannons, diddy, dixie", "HARD, carry, controllablebarrels, kongbarrels, barrelkannons, diddy, dixie", "HARD, teamattack, barrelkannons, controllablebarrels, kongbarrels, diddy, dixie"],
+                "access_rules": ["EASY, controllablebarrels, kongbarrels, barrelkannons, dixie, cartwheel", "EASY, controllablebarrels, kongbarrels, barrelkannons, dixie, helicopterspin", "NORMAL, controllablebarrels, kongbarrels, barrelkannons, dixie, cartwheel", "NORMAL, controllablebarrels, kongbarrels, barrelkannons, dixie, helicopterspin", "HARD, controllablebarrels, kongbarrels, barrelkannons, dixie", "HARD, controllablebarrels, kongbarrels, barrelkannons, dixie, diddy, teamattack"],
                 "chest_unopened_img": "images/checks/kong_disabled.png",
                 "chest_opened_img": "images/checks/kong.png",
                 "visibility_rules": ["kongchecks"],
@@ -127,7 +127,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #2 (Ledge between spikes)",
-                "access_rules": ["EASY, cartwheel", "NORMAL, cartwheel", "HARD"],
+                "access_rules": ["EASY, cartwheel", "EASY, dixie, helicopterspin", "NORMAL, cartwheel", "NORMAL, dixie, helicopterspin", "HARD"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -187,7 +187,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #3 (First Diddy barrel)",
-                "access_rules": ["EASY, kongbarrels, diddy, controllablebarrels", "NORMAL, kongbarrels, diddy, controllablebarrels, cartwheel", "HARD, diddy, kongbarrels, dixie", "HARD, teamattack, diddy, dixie, controllablebarrels"],
+                "access_rules": ["EASY, kongbarrels, diddy, controllablebarrels, cartwheel", "EASY, kongbarrels, diddy, controllablebarrels, dixie, helicopterspin", "NORMAL, kongbarrels, diddy, controllablebarrels, cartwheel", "NORMAL, kongbarrels, diddy, controllablebarrels, dixie, helicopterspin", "HARD, diddy, kongbarrels", "HARD, teamattack, diddy, dixie, controllablebarrels"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -207,7 +207,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #4 (After O)",
-                "access_rules": ["EASY, kongbarrels, diddy, dixie, controllablebarrels", "NORMAL, diddy, cartwheel", "NORMAL, diddy, dixie, helicopterspin", "HARD, controllablebarrels"],
+                "access_rules": ["EASY, kongbarrels, diddy, controllablebarrels, cartwheel", "EASY, kongbarrels, diddy, controllablebarrels, dixie, helicopterspin", "NORMAL, diddy, cartwheel, controllablebarrels", "HARD, controllablebarrels"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -227,7 +227,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #5 (Dixie barrel on split path)",
-                "access_rules": ["EASY, kongbarrels, diddy, dixie, controllablebarrels, barrelkannons", "NORMAL, cartwheel, diddy, barrelkannons", "NORMAL, diddy, dixie, helicopterspin, barrelkannons", "HARD, controllablebarrels, diddy, dixie", "HARD, controllablebarrels, dixie, diddy, kongbarrels"],
+                "access_rules": ["EASY, kongbarrels, dixie, controllablebarrels, barrelkannons, cartwheel", "EASY, kongbarrels, dixie, controllablebarrels, barrelkannons, helicopterspin", "NORMAL, cartwheel, dixie, barrelkannons, controllablebarrels", "NORMAL, controllablebarrels, dixie, helicopterspin, barrelkannons", "HARD, controllablebarrels, dixie, kongbarrels"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -247,7 +247,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #6 (Diddy barrel on split path)",
-                "access_rules": ["EASY, kongbarrels, diddy, dixie, controllablebarrels, barrelkannons", "NORMAL, cartwheel, diddy, dixie, kongbarrels, controllablebarrels, barrelkannons", "HARD, controllablebarrels, diddy, dixie", "HARD, controllablebarrels, dixie, diddy, kongbarrels"],
+                "access_rules": ["EASY, kongbarrels, diddy, controllablebarrels, barrelkannons, cartwheel", "EASY, kongbarrels, dixie, diddy, controllablebarrels, barrelkannons, helicopterspin", "NORMAL, kongbarrels, diddy, controllablebarrels, barrelkannons, cartwheel", "NORMAL, kongbarrels, dixie, diddy, controllablebarrels, barrelkannons, helicopterspin", "HARD, controllablebarrels, dixie, diddy, kongbarrels"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -267,7 +267,7 @@
             "sections": [
                 {
                 "name": "Banana Bunch #7 (After N)",
-                "access_rules": ["EASY, kongbarrels, diddy, dixie, controllablebarrels, barrelkannons", "NORMAL, cartwheel, diddy, dixie, kongbarrels, controllablebarrels, barrelkannons", "HARD, controllablebarrels, diddy, dixie", "HARD, controllablebarrels, dixie, diddy, kongbarrels"],
+                "access_rules": ["EASY, kongbarrels, dixie, controllablebarrels, barrelkannons, cartwheel", "EASY, kongbarrels, dixie, controllablebarrels, barrelkannons, helicopterspin", "NORMAL, kongbarrels, dixie, controllablebarrels, barrelkannons, cartwheel", "NORMAL, kongbarrels, dixie, controllablebarrels, barrelkannons, helicopterspin", "HARD, controllablebarrels, dixie, diddy, kongbarrels"],
                 "chest_unopened_img": "images/checks/bananabunch_disabled.png",
                 "chest_opened_img": "images/checks/bananabunch.png",
                 "visibility_rules": ["bananasanity"],
@@ -287,7 +287,7 @@
             "sections": [
                 {
                 "name": "Banana Coin #4 (Diddy barrel after Klobber trio)",
-                "access_rules": ["EASY, kongbarrels, diddy, dixie, controllablebarrels, barrelkannons", "NORMAL, cartwheel, diddy, dixie, kongbarrels, controllablebarrels, barrelkannons", "HARD, controllablebarrels, diddy, dixie", "HARD, controllablebarrels, dixie, diddy, kongbarrels"],
+                "access_rules": ["EASY, kongbarrels, diddy, controllablebarrels, barrelkannons, cartwheel", "EASY, kongbarrels, dixie, diddy, controllablebarrels, barrelkannons, helicopterspin", "NORMAL, kongbarrels, diddy, controllablebarrels, barrelkannons, cartwheel", "NORMAL, kongbarrels, dixie, diddy, controllablebarrels, barrelkannons, helicopterspin", "HARD, controllablebarrels, dixie, diddy, kongbarrels"],
                 "chest_unopened_img": "images/checks/bananacoin_disabled.png",
                 "chest_opened_img": "images/checks/bananacoin.png",
                 "visibility_rules": ["coinsanity"],
@@ -307,7 +307,7 @@
             "sections": [
                 {
                 "name": "Red Balloon (After long barrel section)",
-                "access_rules": ["EASY, kongbarrels, diddy, dixie, controllablebarrels, barrelkannons", "NORMAL, cartwheel, diddy, dixie, kongbarrels, controllablebarrels, barrelkannons", "HARD, controllablebarrels, cartwheel, diddy, dixie", "HARD, controllablebarrels, cartwheel, dixie, diddy, kongbarrels", "HARD, controllablebarrels, helicopterspin, diddy, dixie", "HARD, controllablebarrels, helicopterspin, dixie, diddy, kongbarrels"],
+                "access_rules": ["EASY, kongbarrels, controllablebarrels, barrelkannons, cartwheel", "EASY, kongbarrels, dixie, controllablebarrels, barrelkannons, helicopterspin", "NORMAL, kongbarrels, controllablebarrels, barrelkannons, cartwheel", "NORMAL, kongbarrels, dixie, controllablebarrels, barrelkannons, helicopterspin", "HARD, controllablebarrels, dixie, diddy, kongbarrels"],
                 "chest_unopened_img": "images/checks/swanky1_disabled.png",
                 "chest_opened_img": "images/checks/swanky1.png",
                 "visibility_rules": ["balloonsanity"],


### PR DESCRIPTION
Animal Antics had too many unneeded dependencies in check logic. EASY logic includes checks for all things to complete a check in a vanilla play, NORMAL includes the minimum needed to complete a check without expecting damage boosting or speedrun/glitch strats.

Resolves https://github.com/pwkfisher/ap-dkc2-tracker/issues/5